### PR TITLE
RpcCaller._setup_link - set mapped file size manually

### DIFF
--- a/lib/mo_rpc.py
+++ b/lib/mo_rpc.py
@@ -22,6 +22,9 @@ class RpcCaller(object):
             with open(filename, "wb") as f:
                 f.write("Hello Python!\n")
         fn = open(filename, "r+")
+        fn.seek(size - 1)
+        fn.write("\0")
+        fn.flush()
         self.data = mmap.mmap(fn.fileno(), size)
         
     def __getattr__(self, value):


### PR DESCRIPTION
Otherwise crashes under linux. Feel free to skip it - not sure whether there is point to run the application under this OS
